### PR TITLE
fix: EPT-4359: [MOB][TSA] Digital scale is still shown as connected after disconnecting USB

### DIFF
--- a/android/src/main/kotlin/hk/gogovan/flutter_device_searcher/UsbSearcher.kt
+++ b/android/src/main/kotlin/hk/gogovan/flutter_device_searcher/UsbSearcher.kt
@@ -15,6 +15,7 @@ import android.os.Build
 import com.hoho.android.usbserial.driver.UsbSerialProber
 import com.hoho.android.usbserial.driver.UsbSerialDriver
 import com.hoho.android.usbserial.driver.UsbSerialPort
+import java.io.IOException
 
 class UsbSearcher(private val context: Context) {
     companion object {
@@ -140,7 +141,17 @@ class UsbSearcher(private val context: Context) {
     }
 
     suspend fun isConnected(): Boolean {
-        return port?.isOpen ?: false
+        if (port?.isOpen != true) {
+            return false
+        }
+        try {
+            // Attempt to read control info to determine whether the connection is active.
+            port?.controlLines
+            return true
+        } catch (e: IOException) {
+            port?.close()
+            return false
+        }
     }
 
     suspend fun disconnectDevice() {

--- a/android/src/main/kotlin/hk/gogovan/flutter_device_searcher/UsbSearcher.kt
+++ b/android/src/main/kotlin/hk/gogovan/flutter_device_searcher/UsbSearcher.kt
@@ -146,9 +146,16 @@ class UsbSearcher(private val context: Context) {
         }
         try {
             // Attempt to read control info to determine whether the connection is active.
+            // We don't need the result, but rather the call is successful or not. Unfortunately the
+            // library does not provide actual connection out of the box so this hack is used.
             port?.controlLines
             return true
         } catch (e: IOException) {
+            // Actual testing reveals that once the USB is disconnected, this is not possible to
+            // reconnect on the same connection.
+            // May be an OS limitation since upon reconnection a permission dialog is shown, indicating
+            // OS has started a new connection for it.
+            // We close the connection manually for cleanup and avoid future confusion.
             port?.close()
             return false
         }

--- a/lib/device/device_interface.dart
+++ b/lib/device/device_interface.dart
@@ -16,6 +16,9 @@ abstract class DeviceInterface<T extends DeviceSearchResult> {
   bool _connected = false;
 
   /// Whether the device has been connected.
+  /// Certain implementations (such as USB) may elect to close the connection once the device has been found disconnected
+  /// when calling this method.
+  ///
   /// Implementors: This method only check if `connect()` is called and `disconnect()` has not been called.
   /// If there is a underlying connection to maintain, override this method to return the actual connection status,
   /// in conjunction to the state maintained by the DeviceInterface.
@@ -24,6 +27,8 @@ abstract class DeviceInterface<T extends DeviceSearchResult> {
 
   /// Return a stream that provide the status of the connection continuously.
   /// This should be in sync with `isConnected()` method.
+  /// Certain implementations (such as USB) may elect to close the connection once the device has been found disconnected
+  /// when calling this method.
   @mustCallSuper
   Stream<bool> connectStateStream() => _connectedController.stream;
 

--- a/lib/device/device_interface.dart
+++ b/lib/device/device_interface.dart
@@ -16,8 +16,9 @@ abstract class DeviceInterface<T extends DeviceSearchResult> {
   bool _connected = false;
 
   /// Whether the device has been connected.
-  /// Certain implementations (such as USB) may elect to close the connection once the device has been found disconnected
-  /// when calling this method.
+  ///
+  /// For USB, the connection is closed once the device has been found disconnected
+  /// when calling this method due to the OS no longer maintaining the connection once disconnected.
   ///
   /// Implementors: This method only check if `connect()` is called and `disconnect()` has not been called.
   /// If there is a underlying connection to maintain, override this method to return the actual connection status,
@@ -27,8 +28,9 @@ abstract class DeviceInterface<T extends DeviceSearchResult> {
 
   /// Return a stream that provide the status of the connection continuously.
   /// This should be in sync with `isConnected()` method.
-  /// Certain implementations (such as USB) may elect to close the connection once the device has been found disconnected
-  /// when calling this method.
+  ///
+  /// For USB, the connection is closed once the device has been found disconnected
+  /// when calling this method due to the OS no longer maintaining the connection once disconnected.
   @mustCallSuper
   Stream<bool> connectStateStream() => _connectedController.stream;
 

--- a/lib/device/usb/usb_device.dart
+++ b/lib/device/usb/usb_device.dart
@@ -3,6 +3,7 @@ import 'dart:typed_data';
 import 'package:flutter_device_searcher/device/device_interface.dart';
 import 'package:flutter_device_searcher/flutter_device_searcher_platform_interface.dart';
 import 'package:flutter_device_searcher/search_result/usb_result.dart';
+import 'package:rxdart/streams.dart';
 
 class UsbDevice extends DeviceInterface<UsbResult> {
   UsbDevice(super.device);
@@ -11,6 +12,16 @@ class UsbDevice extends DeviceInterface<UsbResult> {
   Future<bool> isConnected() async =>
       await super.isConnected() &&
       await FlutterDeviceSearcherPlatform.instance.isConnected();
+
+  @override
+  Stream<bool> connectStateStream() => CombineLatestStream(
+        [
+          super.connectStateStream(),
+          Stream.periodic(const Duration(seconds: 1))
+              .asyncMap((event) => isConnected()),
+        ],
+        (values) => values[0] && values[1],
+      );
 
   @override
   Future<bool> connectImpl(UsbResult inSearchResult) =>


### PR DESCRIPTION
<!--- Jira Ticket Code -->
## [EPT-4359](https://gogotech.atlassian.net/browse/EPT-4359)
based on https://github.com/gogovan/flutter-device-searcher/pull/12
 
#### What does this change?
- [x] relax isConnected check
- [x] use usb serial library
- [x] update dispose for new usb
- [x] add read stream
- [x] add support for stream read
- [x] update readme
- [x] fix stream failed after reconnect
- [x] fix format
- [x] fix connect state stream and query actual state from time to time
- [x] detect actual disconnection
- [x] update comments

<!--- 
#### How do we test this change?
- [ ] Assertion 1
- [ ] Assertion 2
#### Any screen shot for this change?
-->

[EPT-4359]: https://gogotech.atlassian.net/browse/EPT-4359?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ